### PR TITLE
#v5.13.2 - Release

### DIFF
--- a/MirrorflyShareKit/ShareKitViewModel.swift
+++ b/MirrorflyShareKit/ShareKitViewModel.swift
@@ -15,10 +15,11 @@ import Contacts
 
 let BASE_URL =  "https://api-preprod-sandbox.mirrorfly.com/api/v1/"
 let CONTAINER_ID = "group.com.mirrorfly.qa"
-let LICENSE_KEY = "xxxxxxxxxxxxxxxx"
+let LICENSE_KEY = "XXXXXXXXXXXXXX"
 let IS_LIVE = false
 let APP_NAME = "UiKit"
 let ENABLE_CONTACT_SYNC = false
+
 
 protocol ShareKitDelegate {
     func removeData()

--- a/MirrorflyShareKit/ShareScreen/SharekitShareToViewController.swift
+++ b/MirrorflyShareKit/ShareScreen/SharekitShareToViewController.swift
@@ -1363,7 +1363,7 @@ func userUpdatedTheirProfile(for jid: String, profileDetails: ProfileDetails) {
 }
 
 extension SharekitShareToViewController : GroupEventsDelegate {
-    func didRemoveMemberFromAdmin(groupJid: String, removedAdminMemberJid: String, removedByMemberJid: String) {
+    func didRevokedAdminAccess(groupJid: String, revokedAdminMemberJid: String, revokedByMemberJid: String) {
     }
     
     func didAddNewMemeberToGroup(groupJid: String, newMemberJid: String, addedByMemberJid: String) {

--- a/MirrorflyUIkit.xcodeproj/project.pbxproj
+++ b/MirrorflyUIkit.xcodeproj/project.pbxproj
@@ -858,6 +858,7 @@
 		CEB66AC929AE2DC90084559C /* ShareKitShareViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareKitShareViewModel.swift; sourceTree = "<group>"; };
 		CEBE3BD82959CF1F004E7C49 /* FooterSectionCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = FooterSectionCell.xib; sourceTree = "<group>"; };
 		CEC08B6127E23B0D005E48C5 /* Mirrorfly-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Mirrorfly-Info.plist"; path = "/Users/user/Desktop/UiKit/Mirrorfly-Info.plist"; sourceTree = "<absolute>"; };
+		CEC08B7227E23B9F005E48C5 /* MirrorflyNotificationExtention-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "MirrorflyNotificationExtention-Info.plist"; path = "/Users/user/Desktop/UiKit/MirrorflyNotificationExtention-Info.plist"; sourceTree = "<absolute>"; };
 		CEC08B7427E243D9005E48C5 /* MirrorflyNotificationextention.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = MirrorflyNotificationextention.entitlements; sourceTree = "<group>"; };
 		CEC08B7E27E24F41005E48C5 /* GoogleService-Qa-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Qa-Info.plist"; sourceTree = "<group>"; };
 		CEC2D48827A5AAA700AB107A /* ContactInfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactInfoViewModel.swift; sourceTree = "<group>"; };
@@ -2692,6 +2693,7 @@
 				CEC08B7427E243D9005E48C5 /* MirrorflyNotificationextention.entitlements */,
 				CEF43750273BCAB2008D0F39 /* NotificationExtentionQa.entitlements */,
 				CEF43746273BCA77008D0F39 /* NotificationService.swift */,
+				CEC08B7227E23B9F005E48C5 /* MirrorflyNotificationExtention-Info.plist */,
 				CEF43748273BCA77008D0F39 /* Info.plist */,
 			);
 			path = NotificationExtention;

--- a/MirrorflyUIkit.xcodeproj/xcshareddata/xcschemes/MirrorflyShareKit.xcscheme
+++ b/MirrorflyUIkit.xcodeproj/xcshareddata/xcschemes/MirrorflyShareKit.xcscheme
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1500"
+   wasCreatedForAppExtension = "YES"
    version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,9 +15,23 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "CEC08B6227E23B9F005E48C5"
-               BuildableName = "MirrorflyNotificationExtention.appex"
-               BlueprintName = "MirrorflyNotificationExtention"
+               BlueprintIdentifier = "CEE7C59C299F6505002F22FA"
+               BuildableName = "MirrorflyShareKit.appex"
+               BlueprintName = "MirrorflyShareKit"
+               ReferencedContainer = "container:MirrorflyUIkit.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CEC08A9C27E23B0D005E48C5"
+               BuildableName = "Mirrorfly.app"
+               BlueprintName = "Mirrorfly"
                ReferencedContainer = "container:MirrorflyUIkit.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -26,9 +41,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -42,6 +56,16 @@
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES"
       launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CEC08A9C27E23B0D005E48C5"
+            BuildableName = "Mirrorfly.app"
+            BlueprintName = "Mirrorfly"
+            ReferencedContainer = "container:MirrorflyUIkit.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -51,15 +75,16 @@
       debugDocumentVersioning = "YES"
       askForAppToLaunch = "Yes"
       launchAutomaticallySubstyle = "2">
-      <MacroExpansion>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "CEC08B6227E23B9F005E48C5"
-            BuildableName = "MirrorflyNotificationExtention.appex"
-            BlueprintName = "MirrorflyNotificationExtention"
+            BlueprintIdentifier = "CEC08A9C27E23B0D005E48C5"
+            BuildableName = "Mirrorfly.app"
+            BlueprintName = "Mirrorfly"
             ReferencedContainer = "container:MirrorflyUIkit.xcodeproj">
          </BuildableReference>
-      </MacroExpansion>
+      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/MirrorflyUIkit.xcodeproj/xcshareddata/xcschemes/UikitQaShareKit.xcscheme
+++ b/MirrorflyUIkit.xcodeproj/xcshareddata/xcschemes/UikitQaShareKit.xcscheme
@@ -73,6 +73,7 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES"
+      askForAppToLaunch = "Yes"
       launchAutomaticallySubstyle = "2">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/MirrorflyUIkit/Chat/ChatViewParentController.swift
+++ b/MirrorflyUIkit/Chat/ChatViewParentController.swift
@@ -7015,8 +7015,8 @@ extension ChatViewParentController : GroupEventsDelegate {
         
     }
     
-    func didRemoveMemberFromAdmin(groupJid: String, removedAdminMemberJid: String, removedByMemberJid: String) {
-        
+    func didRevokedAdminAccess(groupJid: String, revokedAdminMemberJid: String, revokedByMemberJid: String) {
+        checkMemberOfGroup()
     }
     
     func didDeleteGroupLocally(groupJid: String) {

--- a/MirrorflyUIkit/Chat/ScheduledMeeting/InstantScheduledMeetingViewController.swift
+++ b/MirrorflyUIkit/Chat/ScheduledMeeting/InstantScheduledMeetingViewController.swift
@@ -304,7 +304,7 @@ extension InstantScheduledMeetingViewController : GroupEventsDelegate {
 
     }
 
-    func didRemoveMemberFromAdmin(groupJid: String, removedAdminMemberJid: String, removedByMemberJid: String) {
+    func didRevokedAdminAccess(groupJid: String, revokedAdminMemberJid: String, revokedByMemberJid: String) {
 
     }
 

--- a/MirrorflyUIkit/Controllers/Delegates/AppDelegate.swift
+++ b/MirrorflyUIkit/Controllers/Delegates/AppDelegate.swift
@@ -21,7 +21,7 @@ import AVFoundation
 import MirrorFlySDK
 
 let BASE_URL = "https://api-preprod-sandbox.mirrorfly.com/api/v1/"
-let LICENSE_KEY = "xxxxxxxxxxxxxxxx"
+let LICENSE_KEY = "XXXXXXXXXXXXXX"
 let XMPP_DOMAIN = "xmpp-preprod-sandbox.mirrorfly.com"
 let XMPP_PORT = 5222
 let SOCKETIO_SERVER_HOST = "https://signal-preprod-sandbox.mirrorfly.com"

--- a/MirrorflyUIkit/Controllers/ForwardMessages/ForwardViewController.swift
+++ b/MirrorflyUIkit/Controllers/ForwardMessages/ForwardViewController.swift
@@ -1142,7 +1142,7 @@ func userUpdatedTheirProfile(for jid: String, profileDetails: ProfileDetails) {
 }
 
 extension ForwardViewController : GroupEventsDelegate {
-    func didRemoveMemberFromAdmin(groupJid: String, removedAdminMemberJid: String, removedByMemberJid: String) {
+    func didRevokedAdminAccess(groupJid: String, revokedAdminMemberJid: String, revokedByMemberJid: String) {
     }
     
     func didAddNewMemeberToGroup(groupJid: String, newMemberJid: String, addedByMemberJid: String) {

--- a/MirrorflyUIkit/Controllers/Image/ImageEditController.swift
+++ b/MirrorflyUIkit/Controllers/Image/ImageEditController.swift
@@ -1112,7 +1112,7 @@ extension ImageEditController: GroupEventsDelegate {
         
     }
     
-    func didRemoveMemberFromAdmin(groupJid: String, removedAdminMemberJid: String, removedByMemberJid: String) {
+    func didRevokedAdminAccess(groupJid: String, revokedAdminMemberJid: String, revokedByMemberJid: String) {
         
     }
     

--- a/MirrorflyUIkit/Controllers/RecentChat/RecentChatViewController.swift
+++ b/MirrorflyUIkit/Controllers/RecentChat/RecentChatViewController.swift
@@ -2512,7 +2512,7 @@ extension RecentChatViewController : GroupCreationDelegate {
 }
 
 extension RecentChatViewController : GroupEventsDelegate {
-    func didRemoveMemberFromAdmin(groupJid: String, removedAdminMemberJid: String, removedByMemberJid: String) {
+    func didRevokedAdminAccess(groupJid: String, revokedAdminMemberJid: String, revokedByMemberJid: String) {
         DispatchQueue.main.async { [weak self] in
             self?.updateGroupInRecentChat(groupJid: groupJid)
         }

--- a/MirrorflyUIkit/Group Info Options/Controller/GroupInfoOptionsViewController.swift
+++ b/MirrorflyUIkit/Group Info Options/Controller/GroupInfoOptionsViewController.swift
@@ -17,8 +17,9 @@ class GroupInfoOptions {
     }
 }
 
-protocol GroupInfoOptionsDelegate: class {
+protocol GroupInfoOptionsDelegate: AnyObject {
     func makeGroupAdmin(groupID: String, userJid: String, userName: String)
+    func removeGroupAdmin(groupID: String, userJid: String, userName: String)
     func removeParticipant(groupID: String, removeGroupMemberJid: String, userName: String)
     func navigateToUserProfile(userJid: String)
     func navigateToChat(userJid: String)

--- a/MirrorflyUIkit/Group Info/Controller/GroupInfoViewController.swift
+++ b/MirrorflyUIkit/Group Info/Controller/GroupInfoViewController.swift
@@ -753,6 +753,10 @@ extension GroupInfoViewController: AddParticipantsDelegate {
 }
 
 extension GroupInfoViewController: GroupInfoOptionsDelegate {
+    func removeGroupAdmin(groupID: String, userJid: String, userName: String) {
+        
+    }
+    
     
     func makeGroupAdmin(groupID: String, userJid: String, userName: String) {
         
@@ -804,12 +808,16 @@ extension GroupInfoViewController: GroupInfoOptionsDelegate {
         AppAlert.shared.onAlertAction = { [weak self] (result) -> Void in
             let isBlocked = self?.groupInfoViewModel.isBlockedByAdmin(groupJid: self?.groupID ?? "") ?? false
             if result == 0 && !isBlocked {
-                self?.groupInfoViewModel.removeParticipantFromGroup(groupID: groupID, removeGroupMemberJid: removeGroupMemberJid) { [weak self] success in
+                self?.groupInfoViewModel.removeParticipantFromGroup(groupID: groupID, removeGroupMemberJid: removeGroupMemberJid) { [weak self] success,FlyError,data  in
                     if self?.isAdminMember == true {
                         if success {
                             self?.getGroupMembers()
                             self?.refreshData()
                             AppAlert.shared.showToast(message: removeUserStatus)
+                        } else {
+                            self?.getGroupMembers()
+                            self?.refreshData()
+                            AppAlert.shared.showToast(message: FlyError?.description ?? "")
                         }
                     } else {
                         self?.getGroupMembers()
@@ -965,8 +973,8 @@ extension GroupInfoViewController : GroupEventsDelegate {
         tableView.reloadSections(IndexSet(integer: 3), with: .none)
     }
     
-    func didRemoveMemberFromAdmin(groupJid: String, removedAdminMemberJid: String, removedByMemberJid: String) {
-        if let row = self.groupMembers.firstIndex(where: {$0.memberJid == removedAdminMemberJid}) {
+    func didRevokedAdminAccess(groupJid: String, revokedAdminMemberJid: String, revokedByMemberJid: String) {
+        if let row = self.groupMembers.firstIndex(where: {$0.memberJid == revokedAdminMemberJid}) {
             groupMembers[row].isAdminMember = false
         }
         tableView.reloadSections(IndexSet(integer: 3), with: .none)

--- a/MirrorflyUIkit/Group Info/Controller/GroupInfoViewModel.swift
+++ b/MirrorflyUIkit/Group Info/Controller/GroupInfoViewModel.swift
@@ -56,13 +56,12 @@ class GroupInfoViewModel: NSObject {
         }
     }
     
+    
     func removeParticipantFromGroup(groupID: String, removeGroupMemberJid: String,
-                                    completionHandler: @escaping (Bool) -> Void) {
+                                    completionHandler: @escaping FlyCompletionHandler) {
         
         try! GroupManager.shared.removeParticipantFromGroup(groupId: groupID,
-                                                            removeGroupMemberJid: removeGroupMemberJid) { isSuccess, error, data in
-            completionHandler(isSuccess)
-        }
+                                                            removeGroupMemberJid: removeGroupMemberJid, completionHandler: completionHandler)
     }
     
     func removeGroupProfileImage(groupID: String, completionHandler: @escaping(_ isSuccess: Bool,

--- a/MirrorflyUIkit/Plist/MirrorflyUIkit-info.plist
+++ b/MirrorflyUIkit/Plist/MirrorflyUIkit-info.plist
@@ -49,7 +49,7 @@
 		<string>SF-UI-Display-Heavy.otf</string>
 	</array>
 	<key>googleApiKey</key>
-	<string>xxxx</string>
+	<string>XXXXXXXXXXXXXX</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>comgooglemaps</string>
@@ -157,6 +157,6 @@
 	<key>UIUserInterfaceStyle</key>
 	<string>Light</string>
 	<key>googleApiKey_Translation</key>
-	<string>xxxx</string>
+	<string>XXXXXXXXXXXXXX</string>
 </dict>
 </plist>

--- a/MirrorflyUIkit/group/GroupCreationViewModel.swift
+++ b/MirrorflyUIkit/group/GroupCreationViewModel.swift
@@ -99,16 +99,10 @@ class GroupCreationViewModel : NSObject {
     }
     
     func addNewParticipantToGroup(groupID: String,
-                                  completionHandler: @escaping (Bool) -> Void) {
+                                  completionHandler: @escaping FlyCompletionHandler) {
         
         let contactList = getParticiapntsJID()
         
-        try! GroupManager.shared.addParticipantToGroup(groupId: groupID,                                                                   newUserJidList: contactList) { isSuccess, error, data in
-            
-            if isSuccess {
-                print("SUCCESSSS")
-            }
-            completionHandler(isSuccess)
-        }
+        try! GroupManager.shared.addParticipantToGroup(groupId: groupID, newUserJidList: contactList, completionHandler: completionHandler)
     }
 }

--- a/MirrorflyUIkit/group/addParticipants/AddParticipantsViewController.swift
+++ b/MirrorflyUIkit/group/addParticipants/AddParticipantsViewController.swift
@@ -151,12 +151,17 @@ class AddParticipantsViewController: UIViewController {
                 AppAlert.shared.showToast(message: "Please select minimum one Participant")
                 return
             }
-            groupCreationViewModel.addNewParticipantToGroup(groupID: groupID) { [weak self] success in
+            groupCreationViewModel.addNewParticipantToGroup(groupID: groupID) { [weak self] success,error,data  in
                 if success {
                     self?.groupCreationViewModel.initializeGroupCreationData()
                     self?.navigationController?.popViewController(animated: true)
                     self?.delegate?.updatedAddParticipants()
                     AppAlert.shared.showToast(message: "Members added successfully")
+                } else {
+                    self?.groupCreationViewModel.initializeGroupCreationData()
+                    self?.navigationController?.popViewController(animated: true)
+                    self?.delegate?.updatedAddParticipants()
+                    AppAlert.shared.showToast(message: error?.errorDescription ?? "")
                 }
             }
             

--- a/NotificationExtention/NotificationService.swift
+++ b/NotificationExtention/NotificationService.swift
@@ -12,10 +12,11 @@ import MirrorFlySDK
 
 let BASE_URL =  "https://api-preprod-sandbox.mirrorfly.com/api/v1/"
 let CONTAINER_ID = "group.com.mirrorfly.qa"
-let LICENSE_KEY = "xxxxxxxxxxxxxxxx"
+let LICENSE_KEY = "XXXXXXXXXXXXXX"
 let IS_LIVE = false
 let APP_NAME = "UiKit"
 let ENABLE_CONTACT_SYNC = false
+
 
 let isHideNotificationContent = false
 

--- a/Podfile
+++ b/Podfile
@@ -31,13 +31,13 @@ def uikit_pods
   pod 'lottie-ios'
   pod 'BottomSheet', :git => 'https://github.com/joomcode/BottomSheet'
   
-  pod 'MirrorFlySDK', '5.13.0'
+  pod 'MirrorFlySDK', '5.13.2'
 
 end
 
 def notification_pods
 
-  pod 'MirrorFlySDK', '5.13.0'
+  pod 'MirrorFlySDK', '5.13.2'
 
 end
 


### PR DESCRIPTION
Revoke admin in Group has been newly introduced in SDK. You can revoke a admin user from a group to a normal user if you are an admin in that group using the method GroupManager.shared.revokeAdmin(groupJid: groupID, revokeAdminJid: userJid).